### PR TITLE
fix(code): ignore code blocks

### DIFF
--- a/example.py
+++ b/example.py
@@ -105,11 +105,18 @@ class MarkdownAddNumberedNums(sublime_plugin.TextCommand):
         return items
 
     def get_code_blocks(self):
-        """Find code blocks defined by triple backticks."""
+        """Find code blocks defined by triple and quadruple backticks."""
+        # Triple backticks
         code_block_pattern = r"```(?:\s*(\w+)?\s*)?([\s\S]*?)```"
         code_blocks = self.view.find_all(code_block_pattern, sublime.IGNORECASE)
 
-        return [(block.begin(), block.end()) for block in code_blocks]
+        # Quadruple backticks
+        quad_code_block_pattern = r"````(?:\s*(\w+)?\s*)?([\s\S]*?)````"
+        quad_code_blocks = self.view.find_all(quad_code_block_pattern, sublime.IGNORECASE)
+
+        # Combine results and return
+        all_code_blocks = code_blocks + quad_code_blocks
+        return [(block.begin(), block.end()) for block in all_code_blocks]
 
     def is_out_of_code_blocks(self, heading, code_blocks):
         """Check if a given heading is outside the identified code blocks."""


### PR DESCRIPTION
### 1. Summary

I changed `example.py` so that md_numbered_headers ignores the code blocks between the triple and quadruple backticks. See my MCVE below.

### 2. MCVE

#### 2.1. File

Carriage in the beginning of the file.

`````md
```bash
# Kira pre comment
```

## Kira 1

```python
# Kira first comment

### Kira second comment

## Kira third comment
```

## Kira 2

````md
```python
### Kira first comment inside 4 backticks

# Kira second comment inside 4 backticks
```
````

### Kira 2.1

```bash
#### Kira post comment
```

`````

#### 2.2. Steps to reproduce

I open this file in Sublime Text, place the carriage to the beginning of the file and run the command `markdown_remove_numbered_nums`.

#### 2.3. Current behavior

`````md
```bash
# 1. Kira pre comment
```

## 1.1. Kira 1

```python
# 2. Kira first comment

### 2.1. Kira second comment

## 2.1. Kira third comment
```

## 2.2. Kira 2

````md
```python
### 2.2.1. Kira first comment inside 4 backticks

# 3. Kira second comment inside 4 backticks
```
````

### 3.2. Kira 2.1

```bash
#### 3.2.1. Kira post comment
```

`````

md_numbered_headers doesn’t ignore code blocks. This is hardly what users want.

#### 2.4. Behavior after pull request

`````md
```bash
# Kira pre comment
```

## 1. Kira 1

```python
# Kira first comment

### Kira second comment

## Kira third comment
```

## 2. Kira 2

````md
```python
### Kira first comment inside 4 backticks

# Kira second comment inside 4 backticks
```
````

### 2.1. Kira 2.1

```bash
#### Kira post comment
```

`````

Now md_numbered_headers don’t touch any comments inside code blocks.

### 3. Possible problems

For me, my patch is working successfully, but I don’t know if it breaks some expected behavior for other users.

In any case, it would be nice to add for this package tests (which can then be checked using [**pytest**](https://docs.pytest.org/) or its alternatives) with examples of the expected behavior of the package.

### 4. Environment

I tested my changes on this environment:

1. Microsoft Windows 11 [Version 10.0.22621.3085]
1. Sublime Text 4, Build 4169
1. md_numbered_headers v1.1.1

Thanks.
